### PR TITLE
Skip Composer v2.2 allow-plugins prompt in Quick Start

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,7 @@ mkdir my-first-drupal10-app \
 lando start
 
 # Install a site local drush
-lando composer require drush/drush
+lando composer require -n drush/drush
 
 # Install drupal
 lando drush site:install --db-url=mysql://drupal10:drupal10@database/drupal10 -y
@@ -62,7 +62,7 @@ mkdir my-first-drupal9-app \
 lando start
 
 # Install a site local drush
-lando composer require drush/drush
+lando composer require -n drush/drush
 
 # Install drupal
 lando drush site:install --db-url=mysql://drupal9:drupal9@database/drupal9 -y


### PR DESCRIPTION
Since the upgrade to Composer `2.2`, you get prompted when you run `lando composer` in [Quick Start](https://docs.lando.dev/drupal/getting-started.html#quick-start) commands:

```
$ lando composer require drush/drush
composer/installers contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "composer/installers" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?]
``` 

For more, see [Composer v2.2 prompts to authorize plugins](https://www.drupal.org/project/drupal/issues/3255749).
