### PR TITLE
#31: Use 2-latest composer_version for Drupal 9/10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
+## v1.4.0 - [April 15, 2024](https://github.com/lando/drupal/releases/tag/v1.4.0)
+  
+  * Updated version of Composer used with Drupal 9 and 10 to `2-latest`. [#31](https://github.com/lando/drupal/issues/31)
+
 ## v1.3.0 - [March 8, 2024](https://github.com/lando/drupal/releases/tag/v1.3.0)
+
   * Updated to latest database services.
 
 ## v1.2.0 - [February 26, 2024](https://github.com/lando/drupal/releases/tag/v1.2.0)

--- a/builders/drupal10.js
+++ b/builders/drupal10.js
@@ -19,6 +19,7 @@ module.exports = {
     defaultFiles: {},
     php: '8.1',
     drush: '^11',
+    composer_version: '2-latest',
   },
   builder: (parent, config) => class LandoDrupal10 extends parent {
     constructor(id, options = {}) {

--- a/builders/drupal9.js
+++ b/builders/drupal9.js
@@ -19,6 +19,7 @@ module.exports = {
     defaultFiles: {},
     php: '8.0',
     drush: '^11',
+    composer_version: '2-latest',
   },
   builder: (parent, config) => class LandoDrupal9 extends parent {
     constructor(id, options = {}) {

--- a/docs/config.md
+++ b/docs/config.md
@@ -13,7 +13,7 @@ Here are the configuration options, set to the default values, for this recipe's
 recipe: drupal9
 config:
   php: '8.0'
-  composer_version: '2.2.12'
+  composer_version: '2-latest'
   via: apache:2.4
   webroot: .
   database: mysql:5.7
@@ -61,6 +61,8 @@ recipe: drupal9
 config:
   composer_version: '1.10.1'
 ```
+
+By default, Drupal 9 and 10 use the latest version of Composer 2.x.
 
 ## Choosing a webserver
 

--- a/examples/drupal10/README.md
+++ b/examples/drupal10/README.md
@@ -61,7 +61,7 @@ lando mysql -udrupal10 -pdrupal10 drupal10 -e quit
 
 # Should use a composer version above 2.3.6
 cd drupal10
-[[ $(lando composer --version | cut -d " " -f 3 | awk -v min=2.3.6 -F. '($1 > min) || ($1 == min && $2 > 0) || ($1 == min && $2 == 0 && $3 > 6)') ]]
+lando composer --version | cut -d " " -f 3 | head -n 1 | awk -v min=2.3.6 -F. '($1 > 2) || ($1 == 2 && $2 > 3) || ($1 == 2 && $2 == 3 && $3 > 6)'
 
 # Should use site-local drush if installed
 cd drupal10

--- a/examples/drupal10/README.md
+++ b/examples/drupal10/README.md
@@ -59,6 +59,10 @@ lando php -m | grep xdebug || echo $? | grep 1
 cd drupal10
 lando mysql -udrupal10 -pdrupal10 drupal10 -e quit
 
+# Should use a composer version above 2.3.6
+cd drupal10
+[[ $(lando composer --version | cut -d " " -f 3 | awk -v min=2.3.6 -F. '($1 > min) || ($1 == min && $2 > 0) || ($1 == min && $2 == 0 && $3 > 6)') ]]
+
 # Should use site-local drush if installed
 cd drupal10
 lando composer require drush/drush

--- a/examples/drupal9/README.md
+++ b/examples/drupal9/README.md
@@ -61,7 +61,8 @@ lando mysql -udrupal9 -pdrupal9 drupal9 -e quit
 
 # Should use a composer version above 2.3.6
 cd drupal9
-[[ $(lando composer --version | cut -d " " -f 3 | awk -v min=2.3.6 -F. '($1 > min) || ($1 == min && $2 > 0) || ($1 == min && $2 == 0 && $3 > 6)') ]]
+lando composer --version | cut -d " " -f 3 | head -n 1 | awk -v min=2.3.6 -F. '($1 > 2) || ($1 == 2 && $2 > 3) || ($1 == 2 && $2 == 3 && $3 > 6)'
+
 
 # Should use site-local drush if installed
 cd drupal9

--- a/examples/drupal9/README.md
+++ b/examples/drupal9/README.md
@@ -59,6 +59,10 @@ lando php -m | grep xdebug || echo $? | grep 1
 cd drupal9
 lando mysql -udrupal9 -pdrupal9 drupal9 -e quit
 
+# Should use a composer version above 2.3.6
+cd drupal9
+[[ $(lando composer --version | cut -d " " -f 3 | awk -v min=2.3.6 -F. '($1 > min) || ($1 == min && $2 > 0) || ($1 == min && $2 == 0 && $3 > 6)') ]]
+
 # Should use site-local drush if installed
 cd drupal9
 lando composer require drush/drush


### PR DESCRIPTION
- **#31: Use 2-latest as composer_version for Drupal 9 and 10.**
- **#31: Add Changelog.**

Fixes #31 

### Bare minimum self-checks

> [What do you think of a person who only does the bare minimum?](https://getyarn.io/yarn-clip/dcf80710-425e-478b-bde1-c107bd11e849)

- [x] I've updated this PR with the latest code from `main`
- [x] I've done a cursory QA pass of my code locally
- [x] I've ensured all automated status check and tests pass
- [x] I've [connected this PR to an issue](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues)

### Pieces of flare

- [x] I've written a unit or functional test for my code
- [x] I've updated relevant documentation it my code changes it
- [x] I've updated this repo's README if my code changes it
- [x] I've updated this repo's CHANGELOG with my change unless its a trivial change (like updating a typo in the docs)

### Finally

- [ ] I've [requested a review](https://help.github.com/en/articles/requesting-a-pull-request-review) with relevant people

If you have any issues or need help please join the `#contributors` channel in the [Lando slack](https://www.launchpass.com/devwithlando) and someone will gladly help you out!

You can also check out the [coder guide](https://docs.lando.dev/contrib/coder.html).
