### PR TITLE
disable mbstring for drush with d6

### DIFF
--- a/config/drupal6/php.ini
+++ b/config/drupal6/php.ini
@@ -48,3 +48,7 @@ ignore_repeated_errors = on
 html_errors = off
 display_errors = on
 log_errors = on
+
+; Drupal 6
+mbstring.http_input = pass
+mbstring.http_output = pass


### PR DESCRIPTION
Resolves #98 

Drupal 6 is not compatible with PHP's mbstring functions. They're disabled in Drupal's .htaccess, but Drush doesn't pick up on that so it needs to be set in php.ini so Drush can work properly.
