### PR TITLE
Enable manual dispatch of leia test workflow

### DIFF
--- a/.github/workflows/pr-drupal-tests.yml
+++ b/.github/workflows/pr-drupal-tests.yml
@@ -2,6 +2,7 @@ name: Drupal Tests
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   leia-tests:


### PR DESCRIPTION
This gives maintainers a "Run Workflow" button to run the leia tests. It also enables a rest endpoint so could potentially trigger these tests from the core repo on every release. It gets enabled in the Github UI once this is in main.

https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow