### PR TITLE
feat: update @lando/php to ^1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Updated to [@lando/php@1.12.0](https://github.com/lando/php/releases/tag/v1.12.0) for mod_headers/mod_expires and xdebug log fix
 * Removed `--ansi` flag from composer tooling command to prevent escape codes in redirected output [#157](https://github.com/lando/drupal/issues/157)
 
 ## v1.14.1 - [February 20, 2026](https://github.com/lando/drupal/releases/tag/v1.14.1)

--- a/examples/drupal-defaults/.htaccess
+++ b/examples/drupal-defaults/.htaccess
@@ -1,0 +1,8 @@
+<IfModule mod_headers.c>
+  Header set X-Lando-Test "blazes"
+</IfModule>
+
+<IfModule mod_expires.c>
+  ExpiresActive On
+  ExpiresDefault "access plus 1 hour"
+</IfModule>

--- a/examples/drupal-defaults/README.md
+++ b/examples/drupal-defaults/README.md
@@ -44,6 +44,12 @@ lando exec appserver -- /bin/sh -c 'NO_COLOR=1 composer -V' | grep "Composer ver
 # Should not include ANSI escape codes when output is redirected
 lando composer --version > /tmp/composer-output.txt 2>&1 && ! grep -P '\x1b\[' /tmp/composer-output.txt
 
+# Should have mod_headers enabled and working
+lando exec appserver -- curl -sI localhost | grep -i "X-Lando-Test: blazes"
+
+# Should have mod_expires enabled and working
+lando exec appserver -- curl -sI localhost | grep -i "Expires:"
+
 # Should use the correct default config files
 lando exec appserver -- cat /usr/local/etc/php/conf.d/zzz-lando-my-custom.ini | grep "; LANDODRUPALPHPINI"
 lando exec appserver -- curl -L http://localhost/info.php | grep max_execution_time | grep 91

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@lando/mariadb": "^1.8.0",
         "@lando/mssql": "^1.4.3",
         "@lando/mysql": "^1.6.0",
-        "@lando/php": "^1.11.1",
+        "@lando/php": "^1.12.0",
         "@lando/postgres": "^1.6.0",
         "lodash": "^4.17.21",
         "semver": "^7.7.2"
@@ -1503,9 +1503,9 @@
       "license": "MIT"
     },
     "node_modules/@lando/php": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@lando/php/-/php-1.11.1.tgz",
-      "integrity": "sha512-3l6oEj6iZxL4vj59YbOinfu4ktUXYfHe7UlP1W5wePTaQH9K+RBCg8eCsPBmliQzc9ltX6JqvDYrAx2KN5K8Dw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@lando/php/-/php-1.12.0.tgz",
+      "integrity": "sha512-yHhjdtGv0zgylfOubbWz09ufTr8yfi7so262RDJT5P03T24LfHPOBLFLTtdI8I1k0kzH9phxhQ4aZyex9TMhsg==",
       "bundleDependencies": [
         "@lando/nginx",
         "lodash",
@@ -1522,7 +1522,7 @@
       }
     },
     "node_modules/@lando/php/node_modules/@lando/nginx": {
-      "version": "1.5.0",
+      "version": "1.6.0",
       "bundleDependencies": [
         "lodash"
       ],

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@lando/mariadb": "^1.8.0",
     "@lando/mssql": "^1.4.3",
     "@lando/mysql": "^1.6.0",
-    "@lando/php": "^1.11.1",
+    "@lando/php": "^1.12.0",
     "@lando/postgres": "^1.6.0",
     "lodash": "^4.17.21",
     "semver": "^7.7.2"


### PR DESCRIPTION
## Changes

- Updated `@lando/php` to `^1.12.0`
- Added mod_headers and mod_expires verification tests

## What's in @lando/php v1.12.0

- Enabled mod_headers and mod_expires Apache modules by default ([php#244](https://github.com/lando/php/pull/244))
- Fixed xdebug log file ownership issue when build_as_root or run_as_root creates /tmp/xdebug.log as root ([php#242](https://github.com/lando/php/pull/242))

The test in this PR verifies that mod_headers and mod_expires are now available by default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the underlying `@lando/php` runtime, which can change default Apache/PHP behavior (now enabling `mod_headers`/`mod_expires`) and may affect existing Drupal apps. Test coverage is updated, but runtime dependency bumps can still introduce subtle compatibility issues.
> 
> **Overview**
> Updates the plugin’s PHP service dependency to `@lando/php@^1.12.0` (and lockfile), aligning with upstream changes including default Apache module enablement and an Xdebug log ownership fix.
> 
> Extends the `examples/drupal-defaults` verification suite by adding a `.htaccess` and checks that `mod_headers` and `mod_expires` are enabled and functional, and notes the upgrade in the `CHANGELOG`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5479128f9eb97afd300291efb9ffcd697da37a7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->