### PR TITLE
#188 - Fix for [Regression] Double ports in drush_uri / Error: Invalid URI: Host is malformed.

### DIFF
--- a/builders/_drupaly.js
+++ b/builders/_drupaly.js
@@ -294,7 +294,8 @@ module.exports = {
       // Set DRUSH_OPTIONS_URI based on drush_uri config or proxy settings
       let drushUri = options.drush_uri;
       if (!drushUri) {
-        const proxyUrl = options.proxy[options.proxyService]?.[0];
+        // Get hostname only, in-case of added port number.
+        const proxyUrl = utils.getProxyHostname(options.proxy[options.proxyService]?.[0]);
         if (proxyUrl) {
           // Check SSL setting for the proxy service
           const proxyServiceSsl = options.services[options.proxyService]?.ssl;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,7 @@
 // Modules
 const _ = require('lodash');
 const path = require('path');
+const urlUtility = require('url');
 
 /*
  * Helper to get a phar download and setupcommand
@@ -85,3 +86,32 @@ exports.parseConfig = (recipe, app) => _.merge({}, _.get(app, 'config.config', {
   root: app.root,
   userConfRoot: app._config.userConfRoot,
 });
+
+/*
+ * Helper to get Proxy hostname.
+ */
+exports.getProxyHostname = (proxyUrlString = '') => {
+  // Change format `[hostname][:port]` into `[protocol://][hostname][:port]
+  // Otherwise, it shows bad parsing.
+  // - Port = hostname
+  // - Hostname = <empty>
+  // - Pathname = hostname
+
+  // @todo Can we expose this function upstream and reuse it?
+  // @see https://github.com/lando/core/blob/main/utils/parse-proxy-url.js
+  // E.g. options._app._lando.parseProxyUrl().
+
+  // We add the protocol ourselves, so it can be parsed. We also change all *
+  // occurrences for our magic word __wildcard__, because otherwise the url parser
+  // won't parse wildcards in the hostname correctly.
+  if (_.isString(proxyUrlString)) {
+    try {
+      const urlObject = urlUtility.parse(`http://${proxyUrlString}`.replace(/\*/g, '__wildcard__'));
+      return urlObject.hostname;
+    }
+    catch (error) {
+      return undefined;
+    }
+  }
+  return undefined;
+};


### PR DESCRIPTION
A proposed solution to fix non-standard ports and potentially wildcards in drupal url for drush options.

@see #188 

Needs tests and QA please.

### Bare minimum self-checks

> [What do you think of a person who only does the bare minimum?](https://getyarn.io/yarn-clip/dcf80710-425e-478b-bde1-c107bd11e849)

- [X] I've updated this PR with the latest code from `main`
- [X] I've done a cursory QA pass of my code locally
- [ ] I've ensured all automated status check and tests pass
- [X] I've [connected this PR to an issue](https://help.zenhub.com/support/solutions/articles/43000010350-connecting-pull-requests-to-github-issues)

### Pieces of flare

- [ ] I've written a unit or functional test for my code
- [ ] I've updated relevant documentation it my code changes it
- [ ] I've updated this repo's README if my code changes it
- [ ] I've updated this repo's CHANGELOG with my change unless its a trivial change (like updating a typo in the docs)

### Finally

- [ ] I've [requested a review](https://help.github.com/en/articles/requesting-a-pull-request-review) with relevant people

If you have any issues or need help please join the `#contributors` channel in the [Lando slack](https://www.launchpass.com/devwithlando) and someone will gladly help you out!

You can also check out the [coder guide](https://docs.lando.dev/contrib/coder.html).
